### PR TITLE
Added UIResponderProxyingTests, changed cd_signatureWithProtocol

### DIFF
--- a/Examples/CrutchKitExample/CrutchKitExample.xcodeproj/project.pbxproj
+++ b/Examples/CrutchKitExample/CrutchKitExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0002EF690CCD45DCAED04874 /* libPods-CrutchKitExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EEAD2718EFE314D4437B3982 /* libPods-CrutchKitExample.a */; };
+		9E2F10E51CF0F9E500C0A109 /* UIResponderProxyingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E2F10E41CF0F9E500C0A109 /* UIResponderProxyingTests.m */; };
 		AE43128F18F910DFAEAB565D /* libPods-CrutchKitExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EBEB50098ADA09A0300BE2C3 /* libPods-CrutchKitExampleTests.a */; };
 		DD2B83511C20648500C02CD2 /* CDObserverProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD2B83501C20648500C02CD2 /* CDObserverProxyTests.m */; };
 		DD2B83541C20655B00C02CD2 /* CDInvocationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = DD2B83531C20655B00C02CD2 /* CDInvocationRecorder.m */; };
@@ -40,6 +41,7 @@
 /* Begin PBXFileReference section */
 		20F99E7477829A95D59D1411 /* Pods-CrutchKitExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CrutchKitExampleTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CrutchKitExampleTests/Pods-CrutchKitExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		7DE53511CC88C225046820E1 /* Pods-CrutchKitExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CrutchKitExampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CrutchKitExampleTests/Pods-CrutchKitExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		9E2F10E41CF0F9E500C0A109 /* UIResponderProxyingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIResponderProxyingTests.m; sourceTree = "<group>"; };
 		CABFF275B95F10250CFE2119 /* Pods-CrutchKitExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CrutchKitExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-CrutchKitExample/Pods-CrutchKitExample.release.xcconfig"; sourceTree = "<group>"; };
 		DD2B83501C20648500C02CD2 /* CDObserverProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDObserverProxyTests.m; sourceTree = "<group>"; };
 		DD2B83521C20655B00C02CD2 /* CDInvocationRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDInvocationRecorder.h; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				DD2B83501C20648500C02CD2 /* CDObserverProxyTests.m */,
+				9E2F10E41CF0F9E500C0A109 /* UIResponderProxyingTests.m */,
 				DD70C0A51B1DB68A0096AE1B /* Supporting Files */,
 				DD2B83521C20655B00C02CD2 /* CDInvocationRecorder.h */,
 				DD2B83531C20655B00C02CD2 /* CDInvocationRecorder.m */,
@@ -408,6 +411,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9E2F10E51CF0F9E500C0A109 /* UIResponderProxyingTests.m in Sources */,
 				DDB0C69A1C6F46C60016BFFD /* NSException+CDInvocation.m in Sources */,
 				DD2B83541C20655B00C02CD2 /* CDInvocationRecorder.m in Sources */,
 				DDB0C6941C6F427A0016BFFD /* CDInvocationArgument.m in Sources */,

--- a/Examples/CrutchKitExample/CrutchKitExampleTests/CDInvocationHandler.m
+++ b/Examples/CrutchKitExample/CrutchKitExampleTests/CDInvocationHandler.m
@@ -57,22 +57,7 @@
         return [self.selectors containsObject:selector];
     }
     
-    static BOOL isReqVals[4] = {NO, NO, YES, YES};
-    static BOOL isInstanceVals[4] = {NO, YES, NO, YES};
-    struct objc_method_description methodDescription = {NULL, NULL};
-    
-    for(int i = 0; i < 4; i++) {
-        methodDescription = protocol_getMethodDescription(self.protocol,
-                                                          aSelector,
-                                                          isReqVals[i],
-                                                          isInstanceVals[i]);
-        
-        if(methodDescription.types != NULL && methodDescription.name != NULL){
-            return YES;
-        }
-    }
-    
-    return NO;
+    return [NSMethodSignature cd_signatureWithProtocol:self.protocol selector:aSelector] != nil;
 }
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {

--- a/Examples/CrutchKitExample/CrutchKitExampleTests/NSMethodSignature+CDInvocation.m
+++ b/Examples/CrutchKitExample/CrutchKitExampleTests/NSMethodSignature+CDInvocation.m
@@ -12,9 +12,21 @@
 @implementation NSMethodSignature (CDInvocation)
 
 + (instancetype)cd_signatureWithProtocol:(Protocol *)protocol
-                             selector:(SEL)selector {
-    struct objc_method_description description = protocol_getMethodDescription(protocol, selector, NO, YES);
-    return [NSMethodSignature signatureWithObjCTypes:description.types];
+                                selector:(SEL)selector {
+    
+    // checking all methods of a protocol (class methods, instance methods, optional methods, required methods)
+    struct { BOOL isRequired; BOOL isInstance; } opts[4] = { {YES, YES}, {NO, YES}, {YES, NO}, {NO, NO} };
+    for(int i = 0; i < 4; i++)
+    {
+        struct objc_method_description methodDescription = protocol_getMethodDescription(protocol,
+                                                                                         selector,
+                                                                                         opts[i].isRequired,
+                                                                                         opts[i].isInstance);
+        if (methodDescription.name != NULL) {
+            return [NSMethodSignature signatureWithObjCTypes:methodDescription.types];
+        }
+    }
+    return nil;
 }
 
 @end

--- a/Examples/CrutchKitExample/CrutchKitExampleTests/UIResponderProxyingTests.m
+++ b/Examples/CrutchKitExample/CrutchKitExampleTests/UIResponderProxyingTests.m
@@ -1,0 +1,152 @@
+//
+//  UIResponderProxyingTests.m
+//  CrutchKitExample
+//
+//  Created by m.rakhmanov on 21.05.16.
+//  Copyright © 2016 cognitivedisson. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <CDProxying.h>
+#import "CDInvocationHandler.h"
+#import "CDInvocationArgument.h"
+#import <CDProxy/Proxy/CDProxy.h>
+
+@interface UIResponderProxyingTests : XCTestCase
+
+@end
+
+@implementation UIResponderProxyingTests
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testThatProxyIsInsertedInResponderChain {
+    
+    // given
+    
+    UIResponder* responder = [UIResponder new];
+    id proxy = CDProtcolHandler(@protocol(CDProxy));
+    
+    // when
+    
+    [responder cd_insertProxyInResponderChain:proxy];
+    
+    // then
+    
+    XCTAssert(responder.cd_defaultProxy == proxy);
+}
+
+- (void)testThatProxyIsRemovedFromResponderChain {
+    
+    // given
+    
+    UIResponder* responder = [UIResponder new];
+    id proxy = CDProtcolHandler(@protocol(CDProxy));
+    
+    [responder cd_insertProxyInResponderChain:proxy];
+    
+    // when
+    
+    [responder cd_removeProxyFromResponderChain];
+    
+    // then
+    
+    XCTAssert(responder.cd_defaultProxy == nil);
+}
+
+- (void)testThatResponderChainIsCorrectlyFilledOut {
+    
+    // given
+    
+    UIView* view1 = [UIView new];
+    UIView* view2 = [UIView new];
+    [view1 addSubview:view2];
+    
+    // when
+    
+    NSArray *chain = [view2 cd_responderChain];
+    
+    // then
+    
+    XCTAssert([chain containsObject:view1]);
+    XCTAssert([chain containsObject:view2]);
+}
+
+- (void)testThatCDProxyForProtocolCallsExpectedMethodOfCDProxy {
+    
+    // given
+    
+    id proxy = CDProtcolHandler(@protocol(CDProxy));
+    [[proxy expect] proxyProtocol:@protocol(CDProxy)];
+    
+    UIView* view1 = [UIView new];
+    UIView* view2 = [UIView new];
+    [view1 addSubview:view2];
+    
+    [view1 cd_insertProxyInResponderChain:proxy];
+    
+    // when
+    
+    [view2 cd_proxyForProtocol:@protocol(CDProxy)];
+    
+    // then
+    
+    [proxy performVerification];
+}
+
+- (void)testThatCDProxyForSelectorCallsExpectedMethodOfCDProxy {
+    
+    // given
+    
+    SEL selector = @selector(definition);
+    
+    id proxy = CDProtcolHandler(@protocol(CDProxy));
+    [[proxy expect] proxySelector:selector];
+    
+    UIView* view1 = [UIView new];
+    UIView* view2 = [UIView new];
+    [view1 addSubview:view2];
+    
+    [view1 cd_insertProxyInResponderChain:proxy];
+    
+    // when
+    
+    [view2 cd_proxyForSelector:selector];
+    
+    // then
+    
+    [proxy performVerification];
+}
+
+- (void)testThatCDProxyForProtocolSelectorCallsExpectedMethodOfCDProxy {
+    
+    // given
+    
+    SEL selector = @selector(definition);
+    Protocol *protocol = @protocol(CDProxy);
+    
+    id proxy = CDProtcolHandler(protocol);
+    [[proxy expect] proxyProtocol:protocol selector:selector];
+    
+    UIView* view1 = [UIView new];
+    UIView* view2 = [UIView new];
+    [view1 addSubview:view2];
+    
+    [view1 cd_insertProxyInResponderChain:proxy];
+    
+    // when
+    
+    [view2 cd_proxyForProtocol:protocol selector:selector];
+    
+    // then
+    
+    [proxy performVerification];
+}
+
+@end

--- a/Examples/CrutchKitExample/CrutchKitExampleTests/UIResponderProxyingTests.m
+++ b/Examples/CrutchKitExample/CrutchKitExampleTests/UIResponderProxyingTests.m
@@ -29,51 +29,42 @@
 - (void)testThatProxyIsInsertedInResponderChain {
     
     // given
-    
     UIResponder* responder = [UIResponder new];
     id proxy = CDProtcolHandler(@protocol(CDProxy));
     
     // when
-    
     [responder cd_insertProxyInResponderChain:proxy];
     
     // then
-    
-    XCTAssert(responder.cd_defaultProxy == proxy);
+    XCTAssertEqualObjects(responder.cd_defaultProxy, proxy);
 }
 
 - (void)testThatProxyIsRemovedFromResponderChain {
     
     // given
-    
     UIResponder* responder = [UIResponder new];
     id proxy = CDProtcolHandler(@protocol(CDProxy));
     
     [responder cd_insertProxyInResponderChain:proxy];
     
     // when
-    
     [responder cd_removeProxyFromResponderChain];
     
     // then
-    
-    XCTAssert(responder.cd_defaultProxy == nil);
+    XCTAssertNil(responder.cd_defaultProxy);
 }
 
 - (void)testThatResponderChainIsCorrectlyFilledOut {
     
     // given
-    
     UIView* view1 = [UIView new];
     UIView* view2 = [UIView new];
     [view1 addSubview:view2];
     
     // when
-    
     NSArray *chain = [view2 cd_responderChain];
     
     // then
-    
     XCTAssert([chain containsObject:view1]);
     XCTAssert([chain containsObject:view2]);
 }
@@ -81,7 +72,6 @@
 - (void)testThatCDProxyForProtocolCallsExpectedMethodOfCDProxy {
     
     // given
-    
     id proxy = CDProtcolHandler(@protocol(CDProxy));
     [[proxy expect] proxyProtocol:@protocol(CDProxy)];
     
@@ -92,18 +82,55 @@
     [view1 cd_insertProxyInResponderChain:proxy];
     
     // when
-    
     [view2 cd_proxyForProtocol:@protocol(CDProxy)];
     
     // then
+    [proxy performVerification];
+}
+
+- (void)testThatCDProxyForProtocolFailsToFindIncorrectProtocol {
     
+    // given
+    id proxy = CDProtcolHandler(@protocol(CDProxy));
+    [[proxy reject] proxyProtocol:@protocol(CDProxy)];
+    [[proxy expect] proxyProtocol:@protocol(UITableViewDelegate)];
+    
+    UIView* view1 = [UIView new];
+    UIView* view2 = [UIView new];
+    [view1 addSubview:view2];
+    
+    [view1 cd_insertProxyInResponderChain:proxy];
+    
+    // when
+    [view2 cd_proxyForProtocol:@protocol(UITableViewDelegate)];
+    
+    // then
+    [proxy performVerification];
+}
+
+- (void)testThatCDProxyForProtocolFailsToFindDeletedProtocol {
+    
+    // given
+    id proxy = CDProtcolHandler(@protocol(CDProxy));
+    [[proxy reject] proxyProtocol:@protocol(CDProxy)];
+    
+    UIView* view1 = [UIView new];
+    UIView* view2 = [UIView new];
+    [view1 addSubview:view2];
+    
+    [view1 cd_insertProxyInResponderChain:proxy];
+    [view1 cd_removeProxyFromResponderChain];
+    
+    // when
+    [view2 cd_proxyForProtocol:@protocol(CDProxy)];
+    
+    // then
     [proxy performVerification];
 }
 
 - (void)testThatCDProxyForSelectorCallsExpectedMethodOfCDProxy {
     
     // given
-    
     SEL selector = @selector(definition);
     
     id proxy = CDProtcolHandler(@protocol(CDProxy));
@@ -116,18 +143,15 @@
     [view1 cd_insertProxyInResponderChain:proxy];
     
     // when
-    
     [view2 cd_proxyForSelector:selector];
     
     // then
-    
     [proxy performVerification];
 }
 
 - (void)testThatCDProxyForProtocolSelectorCallsExpectedMethodOfCDProxy {
     
     // given
-    
     SEL selector = @selector(definition);
     Protocol *protocol = @protocol(CDProxy);
     
@@ -141,11 +165,9 @@
     [view1 cd_insertProxyInResponderChain:proxy];
     
     // when
-    
     [view2 cd_proxyForProtocol:protocol selector:selector];
     
     // then
-    
     [proxy performVerification];
 }
 


### PR DESCRIPTION
Added UIResponderProxyingTests, changed cd_signatureWithProtocol selector, so it would allow to search for any method type in a protocol (i.e., class, instance, optional, required). Would be glad to discuss:-)
